### PR TITLE
Fixed Page search shortcut info for Mac

### DIFF
--- a/Na'viteri.html
+++ b/Na'viteri.html
@@ -560,7 +560,7 @@
                 <br />
                 <br />To search something in this file, use the following keyboard shortcut:
                 <br />PC: Ctrl+F or F3
-                <br />Mac: Option+F
+                <br />Mac: command(⌘)+F
             </span>
         </p>
         <p>


### PR DESCRIPTION
I've just now noticed that the text which tells how to search the page has had the incorrect shortcut for Mac. Fixed :)